### PR TITLE
allow verify certificate chain in client mode (optional)

### DIFF
--- a/stunnel.conf.template
+++ b/stunnel.conf.template
@@ -10,6 +10,7 @@ socket = l:TCP_NODELAY=1
 socket = r:TCP_NODELAY=1
 
 CAfile = ${STUNNEL_CAFILE}
+verifyChain = ${STUNNEL_VERIFY_CHAIN}
 
 debug = ${STUNNEL_DEBUG}
 output = /var/log/stunnel/stunnel.log

--- a/stunnel.sh
+++ b/stunnel.sh
@@ -5,6 +5,7 @@ export STUNNEL_DEBUG="${STUNNEL_DEBUG:-7}"
 export STUNNEL_CLIENT="${STUNNEL_CLIENT:-no}"
 #export STUNNEL_SNI="${STUNNEL_SNI:-}"
 export STUNNEL_CAFILE="${STUNNEL_CAFILE:-/etc/ssl/certs/ca-certificates.crt}"
+export STUNNEL_VERIFY_CHAIN="${STUNNEL_VERIFY_CHAIN:-no}"
 export STUNNEL_KEY="${STUNNEL_KEY:-/etc/stunnel/stunnel.key}"
 export STUNNEL_CRT="${STUNNEL_CRT:-/etc/stunnel/stunnel.pem}"
 


### PR DESCRIPTION
* verifyChain allows stunnel to verify the remote certificate chain.
  The default is still no, so it should keep backwards compatibility.