### PR TITLE
Add delay option as STUNNEL_DELAY

### DIFF
--- a/stunnel.conf.template
+++ b/stunnel.conf.template
@@ -20,3 +20,4 @@ client = ${STUNNEL_CLIENT}
 [${STUNNEL_SERVICE}]
 accept = ${STUNNEL_ACCEPT}
 connect = ${STUNNEL_CONNECT}
+delay = ${STUNNEL_DELAY}

--- a/stunnel.sh
+++ b/stunnel.sh
@@ -8,6 +8,7 @@ export STUNNEL_CAFILE="${STUNNEL_CAFILE:-/etc/ssl/certs/ca-certificates.crt}"
 export STUNNEL_VERIFY_CHAIN="${STUNNEL_VERIFY_CHAIN:-no}"
 export STUNNEL_KEY="${STUNNEL_KEY:-/etc/stunnel/stunnel.key}"
 export STUNNEL_CRT="${STUNNEL_CRT:-/etc/stunnel/stunnel.pem}"
+export STUNNEL_DELAY="${STUNNEL_DELAY:-no}"
 
 if [[ -z "${STUNNEL_SERVICE}" ]] || [[ -z "${STUNNEL_ACCEPT}" ]] || [[ -z "${STUNNEL_CONNECT}" ]]; then
     echo >&2 "one or more STUNNEL_SERVICE* values missing: "


### PR DESCRIPTION
Hi!
I'm adding an ability to set the `delay` option with `STUNNEL_DELAY`. I'm using stunnel to protect a redis connection to hosted redis server, because the client library cannot use redis+ssl protocol. After some restart of hosted server, it's IP changed, and stunnel failed to connect for 8 hours causing service downtime. Delay =yes option would prevent this, so I think this adds resilience to this docker image. 