### PR TITLE
Add support for the protocol stunnel parameter

### DIFF
--- a/stunnel.conf.template
+++ b/stunnel.conf.template
@@ -21,3 +21,4 @@ client = ${STUNNEL_CLIENT}
 accept = ${STUNNEL_ACCEPT}
 connect = ${STUNNEL_CONNECT}
 delay = ${STUNNEL_DELAY}
+${STUNNEL_PROTOCOL}

--- a/stunnel.sh
+++ b/stunnel.sh
@@ -9,6 +9,7 @@ export STUNNEL_VERIFY_CHAIN="${STUNNEL_VERIFY_CHAIN:-no}"
 export STUNNEL_KEY="${STUNNEL_KEY:-/etc/stunnel/stunnel.key}"
 export STUNNEL_CRT="${STUNNEL_CRT:-/etc/stunnel/stunnel.pem}"
 export STUNNEL_DELAY="${STUNNEL_DELAY:-no}"
+export STUNNEL_PROTOCOL="${STUNNEL_PROTOCOL:+protocol = ${STUNNEL_PROTOCOL}}"
 
 if [[ -z "${STUNNEL_SERVICE}" ]] || [[ -z "${STUNNEL_ACCEPT}" ]] || [[ -z "${STUNNEL_CONNECT}" ]]; then
     echo >&2 "one or more STUNNEL_SERVICE* values missing: "


### PR DESCRIPTION
Activate the *protocol* stunnel option by passing the *STUNNEL_PROTOCOL* environment variable. Nothing will be added to the config if the variable is not set.