### PR TITLE
added verify

### DIFF
--- a/stunnel.conf.template
+++ b/stunnel.conf.template
@@ -22,3 +22,4 @@ client = ${STUNNEL_CLIENT}
 accept = ${STUNNEL_ACCEPT}
 connect = ${STUNNEL_CONNECT}
 delay = ${STUNNEL_DELAY}
+verify = ${STUNNEL_VERIFY}

--- a/stunnel.sh
+++ b/stunnel.sh
@@ -3,6 +3,7 @@
 export STUNNEL_CONF="/etc/stunnel/stunnel.conf"
 export STUNNEL_DEBUG="${STUNNEL_DEBUG:-7}"
 export STUNNEL_CLIENT="${STUNNEL_CLIENT:-no}"
+export STUNNEL_VERIFY="${STUNNEL_VERIFY:-0}"
 #export STUNNEL_SNI="${STUNNEL_SNI:-}"
 export STUNNEL_CAFILE="${STUNNEL_CAFILE:-/etc/ssl/certs/ca-certificates.crt}"
 export STUNNEL_VERIFY_CHAIN="${STUNNEL_VERIFY_CHAIN:-no}"


### PR DESCRIPTION
hi, 
I would like to add this option. the procedure will be:
1. run server side
2. copy the certificates from server side (docker cp)
3. run the client side with the certificates attached

how to test:
I assume there is some http server in 10.0.0.1:80
##### config

**docker-compose.yml**

version: '3'

networks:
  default:

services:

  stunnel-client:
    image: tmp # dweomer/stunnel
    restart: always
    environment:
      - STUNNEL_SERVICE=srv 
      - STUNNEL_ACCEPT=1234 
      - STUNNEL_CONNECT=stunnel-server:1234 
      - STUNNEL_CLIENT=yes
      - STUNNEL_VERIFY=1
    ports:
      - "6060:1234"
    volumes:
      - ./stunnel.key:/etc/stunnel/stunnel.key:ro
      - ./stunnel.pem:/etc/stunnel/stunnel.pem:ro

  stunnel-server:
    image: tmp # dweomer/stunnel
    restart: always
    environment:
      - STUNNEL_SERVICE=srv 
      - STUNNEL_ACCEPT=1234 
      - STUNNEL_CONNECT=10.0.0.1:80 
      - STUNNEL_VERIFY=1


##### test plan
part 1: working with the key
setup:
docker-compose up -d stunnel-server
docker cp stunnel_stunnel-server_1:/etc/stunnel/stunnel.pem .
docker cp stunnel_stunnel-server_1:/etc/stunnel/stunnel.key .
docker-compose up -d stunnel-client

go to http://127.0.0.1:6060/ - should show the website in 10.0.0.1
docker-compose down


part 2: not working without the key
setup:
docker-compose up -d stunnel-server
docker-compose up -d stunnel-client

go to http://127.0.0.1:6060/ - it will not show anything
docker-compose down

