### PR TITLE
fixes #18 randfile handling

### DIFF
--- a/openssl.cnf
+++ b/openssl.cnf
@@ -1,4 +1,4 @@
-RANDFILE                = /dev/urandom
+RANDFILE                = /srv/stunnel/randfile
 
 [ req ]
 default_bits            = 2048

--- a/stunnel.sh
+++ b/stunnel.sh
@@ -36,7 +36,7 @@ if [[ ! -f ${STUNNEL_KEY} ]]; then
         echo >&2 "crt (${STUNNEL_CRT}) missing key (${STUNNEL_KEY})"
         exit 1
     fi
-
+    openssl rand -writerand /srv/stunnel/randfile
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ${STUNNEL_KEY} -out ${STUNNEL_CRT} \
         -config /srv/stunnel/openssl.cnf 
 fi


### PR DESCRIPTION
I believe this fixes #18, the startup issue during certificate generation.  It changes the entrypoint script to manually create a `randfile` and references it from `openssl.cnf`.